### PR TITLE
[bug] 写死的前缀,在使用多后台或者其他前缀的时候会出问题

### DIFF
--- a/src/Controllers/MenuController.php
+++ b/src/Controllers/MenuController.php
@@ -61,7 +61,7 @@ class MenuController extends Controller
      */
     public function show($id)
     {
-        return redirect()->route('admin.auth.menu.edit', ['menu' => $id]);
+        return redirect()->route(config('admin.route.prefix') .'.auth.menu.edit', ['menu' => $id]);
     }
 
     /**

--- a/src/Controllers/MenuController.php
+++ b/src/Controllers/MenuController.php
@@ -61,7 +61,7 @@ class MenuController extends Controller
      */
     public function show($id)
     {
-        return redirect()->route(config('admin.route.prefix') .'.auth.menu.edit', ['menu' => $id]);
+        return redirect()->route(config('admin.route.prefix') . '.auth.menu.edit', ['menu' => $id]);
     }
 
     /**


### PR DESCRIPTION
这个前缀不应该写死,有时候我的后台不想使用admin作为prefix,这里编辑完菜单就会出问题.在使用多后台的时候会从别的后台跳转到admin菜单编辑后台,需要修复这个bug.